### PR TITLE
change fixity of the operators to be consistent with (<>) from base

### DIFF
--- a/Data/String/Combinators.hs
+++ b/Data/String/Combinators.hs
@@ -90,7 +90,7 @@ import Data.Monoid ( mappend )
 -- Note that: @'<>' = 'mappend'@.
 (<>) :: Monoid s => s -> s -> s
 (<>) = mappend
-infixl 6 <>
+infixr 6 <>
 #endif
 
 --------------------------------------------------------------------------------
@@ -111,8 +111,8 @@ mid m x y = between x y m
 ($$) :: (Monoid s, IsString s) => s -> s -> s
 ($$) = mid newline
 
-infixl 6 <+>
-infixl 5 $$
+infixr 6 <+>
+infixr 5 $$
 
 {-| Combine the string-likes with a given function.
 

--- a/string-combinators.cabal
+++ b/string-combinators.cabal
@@ -1,5 +1,5 @@
 Name:          string-combinators
-Version:       0.6.0.5
+Version:       0.7.0.0
 Synopsis:      Polymorphic functions to build and combine stringlike values
 Description:   @string-combinators@ provides handy polymorphic functions
                to build and combine string-like values.


### PR DESCRIPTION
(<>) from base is defined with infixr 6, so having local (<>) be infixl is rather confusing and makes concatenation of lists inefficient. In addition, it is currently impossible to mix (<>) from base and (<+>) in the same statement without wrapping stuff in parentheses:

``` haskell
λ> "foo" <> "bar:" <+> "baz"

<interactive>:20:1:
    Precedence parsing error
        cannot mix ‘<>’ [infixr 6] and ‘<+>’ [infixl 6] in the same infix expression
```
